### PR TITLE
Only create cert dir when it is in OpenSSL

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.2
+current_version = 0.6.3
 commit = True
 tag = True
 tag_name = v{new_version}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ansible_python_interpreter="/home/core/bin/python"
 
 In order to effectively run ansible, the target machine needs to have a python interpreter. Coreos machines are minimal and do not ship with any version of python. To get around this limitation we can install [pypy](http://pypy.org/), a lightweight python interpreter. The coreos-bootstrap role will install pypy for us and we will update our inventory file to use the installed python interpreter.
 
-Current version: 0.6.2
+Current version: 0.6.3
 
 # install
 

--- a/files/bootstrap.sh
+++ b/files/bootstrap.sh
@@ -56,8 +56,10 @@ sudo chown `whoami` "$ANSIBLE_FACTS_DIR"
 
 PYPY_SSL_PATH=`$PYPY_INSTALL/bin/pypy -c 'from __future__ import print_function; import ssl; print(ssl.get_default_verify_paths().openssl_capath)'`
 
-sudo mkdir -p `dirname $PYPY_SSL_PATH`
-sudo ln -sf $COREOS_SSL_CERTS $PYPY_SSL_PATH
+if [ $PYPY_SSL_PATH != "None" ]; then
+    sudo mkdir -p `dirname $PYPY_SSL_PATH`
+    sudo ln -sf $COREOS_SSL_CERTS $PYPY_SSL_PATH
+fi
 
 PIP_VERSION=`$PYPY_HOME/bin/pip --version | awk '{ print $2 }'`
 WHEEL_VERSION=`$PYPY_HOME/bin/wheel version | awk '{ print $2 }'`


### PR DESCRIPTION
Do not create useless `/tmp/None` when OpenSSL returns nothing. This is mostly a cosmetic change as `/tmp` will be deleted on reboot anyway.