### PR TITLE
update portable-pypy to 5.4.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ coreos_pkg_home: "/home/core"
 
 coreos_pypy_url: "https://bitbucket.org/squeaky/portable-pypy/downloads"
 coreos_pypy_flavor: "linux_x86_64-portable"
-coreos_pypy_version: "5.3.1"
-coreos_pypy_sha256: "73014c3840609a62c0984b9c383652097f0a8c52fb74dd9de70d9df2a9a743ff"
+coreos_pypy_version: "5.4.1"
+coreos_pypy_sha256: "0b59f8e69c7883d454fce6364ab01a5ec6a481ed7f0cc0f1612c3b0c253f7da4"
 
 ansible_facts_dir: "/etc/ansible/facts.d"


### PR DESCRIPTION
this version has no dependency on ncurses5