### PR TITLE
Update coreos_pypy_sha256 variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,6 @@ coreos_pkg_home: "/home/core"
 coreos_pypy_url: "https://bitbucket.org/squeaky/portable-pypy/downloads"
 coreos_pypy_flavor: "linux_x86_64-portable"
 coreos_pypy_version: "5.4.1"
-coreos_pypy_sha256: "0b59f8e69c7883d454fce6364ab01a5ec6a481ed7f0cc0f1612c3b0c253f7da4"
+coreos_pypy_sha256: "8eece61fad3792882499d203babeb76d11cb24e7b476708780e5059b3648e7e1"
 
 ansible_facts_dir: "/etc/ansible/facts.d"


### PR DESCRIPTION
It seems that the portable-pypy 5.4.1 has been updated, got hit with 
```
+ [[ -n 0b59f8e69c7883d454fce6364ab01a5ec6a481ed7f0cc0f1612c3b0c253f7da4 ]]
+ echo '0b59f8e69c7883d454fce6364ab01a5ec6a481ed7f0cc0f1612c3b0c253f7da4  pypy-5.4.1-linux_x86_64-portable.tar.bz2'
+ sha256sum -c pypy-5.4.1-linux_x86_64-portable.tar.bz2.sha256
pypy-5.4.1-linux_x86_64-portable.tar.bz2: FAILED
sha256sum: WARNING: 1 computed checksum did NOT match
```


This PR changes `coreos_pypy_sha256` to use this new hash.